### PR TITLE
Fix missing handler for Minecraft version change

### DIFF
--- a/minecraft_gui_installer.py
+++ b/minecraft_gui_installer.py
@@ -147,6 +147,15 @@ class MinecraftServerGUI(tk.Tk):
                 print(f"Fehler beim Laden der Minecraft-Versionen: {e}")
         threading.Thread(target=run).start()
 
+    def on_minecraft_version_change(self, event=None):
+        """Handle changes in the selected Minecraft version."""
+        server_type = self.server_type.get().lower()
+        mc_version = self.mc_version_cb.get()
+        if server_type == "forge":
+            self.fetch_forge_versions(mc_version)
+        elif server_type == "fabric":
+            self.fetch_fabric_versions(mc_version)
+
     def filter_versions_by_server_type(self, server_type):
         if server_type == "vanilla":
             # alle inkl. snapshots/previews


### PR DESCRIPTION
## Summary
- add handler for Minecraft version combobox

## Testing
- `python -m py_compile minecraft_gui_installer.py`
- `python -m py_compile main.py`
- `python -m py_compile plugins_tab_logic.py modrinth_mod_manager.py plugins_logic_update.py icon_and_darkmode.py gui_design_upgrade.py build_exe.py`
- `python main.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_6847198f5714832e901afc1dc3d7824a